### PR TITLE
FIX BUG：and blank space after 1=1

### DIFF
--- a/src/main/java/io/ebeaninternal/server/expression/NoopExpression.java
+++ b/src/main/java/io/ebeaninternal/server/expression/NoopExpression.java
@@ -70,7 +70,7 @@ class NoopExpression implements SpiExpression {
 
   @Override
   public void addSql(SpiExpressionRequest request) {
-    request.append("1=1");
+    request.append("1=1 ");
   }
 
   @Override


### PR DESCRIPTION
If add ebean.expressionEqualsWithNullAsNoop=true in ebean.properties，and use findCount、findList，it will generate sql like:
 where t0.username = ?  and 1=1and t0.is_deleted = 0 ,
so query will threw SQLException.